### PR TITLE
Add GetRequiredService extension method to IServiceProvider

### DIFF
--- a/src/Microsoft.Extensions.NamedDependencyInjection/ServiceProviderExtensions.cs
+++ b/src/Microsoft.Extensions.NamedDependencyInjection/ServiceProviderExtensions.cs
@@ -93,11 +93,8 @@ namespace Microsoft.Extensions.NamedDependencyInjection
         /// <exception cref="InvalidOperationException">There is no service of type serviceType that registered by specified key.</exception>
         public static object GetRequiredService<TKey>(this IServiceProvider serviceProvider, Type serviceType, TKey key)
         {
-            var service = serviceProvider.GetService(serviceType, key);
-            if (service == null)
-            {
-                throw new InvalidOperationException($"No service for type '{serviceType.FullName}' has been registered.");
-            }
+            var service = serviceProvider.GetService(serviceType, key)
+                ?? throw new InvalidOperationException($"No service for type '{serviceType.FullName}' with key '{key}' has been registered.");
             return service;
         }
 

--- a/src/Microsoft.Extensions.NamedDependencyInjection/ServiceProviderExtensions.cs
+++ b/src/Microsoft.Extensions.NamedDependencyInjection/ServiceProviderExtensions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Extensions.NamedDependencyInjection
         /// <param name="serviceType">An object that specifies the type of service object to get.</param>
         /// <param name="key">A key on which the dependency is registered.</param>
         /// <returns>A service object of type serviceType that registered by specified key.
-        /// If there are no service object or key - null will be returned</returns>
+        /// If there are no service object or key - null will be returned.</returns>
         public static object GetService<TKey>(this IServiceProvider serviceProvider, Type serviceType, TKey key)
         {
             var envelope = serviceProvider
@@ -34,7 +34,7 @@ namespace Microsoft.Extensions.NamedDependencyInjection
         /// <param name="serviceProvider">The System.IServiceProvider to retrieve the service object from.</param>
         /// <param name="key">A key on which the dependency is registered.</param>
         /// <returns>A service object of type T that registered by specified key.
-        /// If there are no service or key - default value will be returned</returns>
+        /// If there are no service or key - default value will be returned.</returns>
         public static T GetService<T, TKey>(this IServiceProvider serviceProvider, TKey key)
         {
             var service = serviceProvider.GetService(typeof(T), key);
@@ -49,7 +49,7 @@ namespace Microsoft.Extensions.NamedDependencyInjection
         /// <param name="serviceProvider">The System.IServiceProvider to retrieve the service object from.</param>
         /// <param name="keyComparer">A comparer function.</param>
         /// <returns>A service object of type T that registered by specified key.
-        /// If there are no service or key - default value will be returned</returns>
+        /// If there are no service or key - default value will be returned.</returns>
         public static T GetService<T, TKey>(this IServiceProvider serviceProvider, Func<TKey, bool> keyComparer)
         {
             var envelope = serviceProvider
@@ -63,6 +63,62 @@ namespace Microsoft.Extensions.NamedDependencyInjection
             }
 
             return (T) envelope.ImplementationFactory(serviceProvider);
+        }
+
+        /// <summary>
+        /// Gets the service of type T by specified key of type TKey.
+        /// </summary>
+        /// <typeparam name="T">The type of service object to get.</typeparam>
+        /// <typeparam name="TKey">The type of key.</typeparam>
+        /// <param name="serviceProvider">The System.IServiceProvider to retrieve the service object from.</param>
+        /// <param name="key">A key on which the dependency is registered.</param>
+        /// <returns>A service object of type T that registered by specified key.
+        /// If there are no service or key - exception will be throwed.</returns>
+        /// <exception cref="InvalidOperationException">There is no service of type serviceType that registered by specified key.</exception>
+        public static T GetRequiredService<T, TKey>(this IServiceProvider serviceProvider, TKey key)
+        {
+            var service = serviceProvider.GetRequiredService(typeof(T), key);
+            return (T)service;
+        }
+
+        /// <summary>
+        /// Gets the service object of the specified type by specified key of type TKey.
+        /// </summary>
+        /// <typeparam name="TKey">The type of key.</typeparam>
+        /// <param name="serviceProvider">The System.IServiceProvider to retrieve the service object from.</param>
+        /// <param name="serviceType">An object that specifies the type of service object to get.</param>
+        /// <param name="key">A key on which the dependency is registered.</param>
+        /// <returns>A service object of type serviceType that registered by specified key.
+        /// If there are no service object or key - exception will be throwed.</returns>
+        /// <exception cref="InvalidOperationException">There is no service of type serviceType that registered by specified key.</exception>
+        public static object GetRequiredService<TKey>(this IServiceProvider serviceProvider, Type serviceType, TKey key)
+        {
+            var service = serviceProvider.GetService(serviceType, key);
+            if (service == null)
+            {
+                throw new InvalidOperationException($"No service for type '{serviceType.FullName}' has been registered.");
+            }
+            return service;
+        }
+
+        /// <summary>
+        /// Gets the service of type T by specified key comparer.
+        /// </summary>
+        /// <typeparam name="T">The type of service object to get.</typeparam>
+        /// <typeparam name="TKey">The type of key.</typeparam>
+        /// <param name="serviceProvider">The System.IServiceProvider to retrieve the service object from.</param>
+        /// <param name="keyComparer">A comparer function.</param>
+        /// <returns>A service object of type T that registered by specified key.
+        /// If there are no service or key - exception will be throwed.</returns>
+        /// <exception cref="InvalidOperationException">There is no service of type serviceType that registered by specified key.</exception>
+        public static T GetRequiredService<T, TKey>(this IServiceProvider serviceProvider, Func<TKey, bool> keyComparer)
+        {
+            var service = serviceProvider.GetService<T, TKey>(keyComparer);
+            if (service == null)
+            {
+                throw new InvalidOperationException($"No service for type '{typeof(T).FullName}' has been registered.");
+            }
+            return service;
         }
     }
 }

--- a/tests/Microsoft.Extensions.NamedDependencyInjection.Tests/ServiceProviderExtensions/ServiceProviderExtensionsTests.cs
+++ b/tests/Microsoft.Extensions.NamedDependencyInjection.Tests/ServiceProviderExtensions/ServiceProviderExtensionsTests.cs
@@ -37,6 +37,16 @@ namespace Microsoft.Extensions.NamedDependencyInjection.Tests.ServiceProviderExt
         }
 
         [Fact]
+        public void GetRequiredServiceByServiceTypeReturnValidService()
+        {
+            var serviceA = serviceProvider.GetRequiredService(typeof(IDummyService), DummyServiceConstants.DummyServiceAKey);
+            var serviceB = serviceProvider.GetRequiredService(typeof(IDummyService), DummyServiceConstants.DummyServiceBKey);
+
+            Assert.NotNull(serviceA as DummyServiceA);
+            Assert.NotNull(serviceB as DummyServiceB);
+        }
+
+        [Fact]
         public void GetServiceByInvalidServiceTypeReturnNull()
         {
             var serviceA = serviceProvider.GetService(typeof(DummyServiceA), DummyServiceConstants.DummyServiceAKey);
@@ -44,6 +54,15 @@ namespace Microsoft.Extensions.NamedDependencyInjection.Tests.ServiceProviderExt
 
             Assert.Null(serviceA);
             Assert.Null(serviceB);
+        }
+
+        [Fact]
+        public void GetRequiredServiceByInvalidServiceTypeThrowException()
+        {
+            Assert.Throws<InvalidOperationException>(() =>
+                serviceProvider.GetRequiredService(typeof(DummyServiceA), DummyServiceConstants.DummyServiceAKey));
+            Assert.Throws<InvalidOperationException>(() =>
+                serviceProvider.GetRequiredService(typeof(DummyServiceB), DummyServiceConstants.DummyServiceBKey));
         }
 
         [Fact]
@@ -57,10 +76,29 @@ namespace Microsoft.Extensions.NamedDependencyInjection.Tests.ServiceProviderExt
         }
 
         [Fact]
+        public void GetRequiredServiceByServiceTypeByInvalidKeyThrowException()
+        {
+            Assert.Throws<InvalidOperationException>(() =>
+                serviceProvider.GetRequiredService(typeof(IDummyService), "non_existing_key_a"));
+            Assert.Throws<InvalidOperationException>(() =>
+                serviceProvider.GetRequiredService(typeof(IDummyService), "non_existing_key_b"));
+        }
+
+        [Fact]
         public void GetServiceByGenericTypeReturnValidService()
         {
             var serviceA = serviceProvider.GetService<IDummyService, string>(DummyServiceConstants.DummyServiceAKey);
             var serviceB = serviceProvider.GetService<IDummyService, string>(DummyServiceConstants.DummyServiceBKey);
+
+            Assert.NotNull(serviceA as DummyServiceA);
+            Assert.NotNull(serviceB as DummyServiceB);
+        }
+
+        [Fact]
+        public void GetRequiredServiceByGenericTypeReturnValidService()
+        {
+            var serviceA = serviceProvider.GetRequiredService<IDummyService, string>(DummyServiceConstants.DummyServiceAKey);
+            var serviceB = serviceProvider.GetRequiredService<IDummyService, string>(DummyServiceConstants.DummyServiceBKey);
 
             Assert.NotNull(serviceA as DummyServiceA);
             Assert.NotNull(serviceB as DummyServiceB);
@@ -77,6 +115,15 @@ namespace Microsoft.Extensions.NamedDependencyInjection.Tests.ServiceProviderExt
         }
 
         [Fact]
+        public void GetRequiredServiceByInvalidGenericTypeThrowException()
+        {
+            Assert.Throws<InvalidOperationException>(() =>
+                serviceProvider.GetRequiredService<DummyServiceA, string>(DummyServiceConstants.DummyServiceAKey));
+            Assert.Throws<InvalidOperationException>(() =>
+                serviceProvider.GetRequiredService<DummyServiceB, string>(DummyServiceConstants.DummyServiceBKey));
+        }
+
+        [Fact]
         public void GetServiceByGenericTypeByInvalidKeyReturnNull()
         {
             var serviceA = serviceProvider.GetService<IDummyService, string>("non_existing_key_a");
@@ -87,11 +134,32 @@ namespace Microsoft.Extensions.NamedDependencyInjection.Tests.ServiceProviderExt
         }
 
         [Fact]
+        public void GetRequiredServiceByGenericTypeByInvalidKeyThrowException()
+        {
+            Assert.Throws<InvalidOperationException>(() =>
+                serviceProvider.GetRequiredService<IDummyService, string>("non_existing_key_a"));
+            Assert.Throws<InvalidOperationException>(() =>
+                serviceProvider.GetRequiredService<IDummyService, string>("non_existing_key_b"));
+        }
+
+        [Fact]
         public void GetServiceByGenericTypeKeyComparerReturnValidService()
         {
             var serviceA = serviceProvider.GetService<IDummyService, string>(
                 key => key == DummyServiceConstants.DummyServiceAKey);
             var serviceB = serviceProvider.GetService<IDummyService, string>(
+                key => key == DummyServiceConstants.DummyServiceBKey);
+
+            Assert.NotNull(serviceA as DummyServiceA);
+            Assert.NotNull(serviceB as DummyServiceB);
+        }
+
+        [Fact]
+        public void GetRequiredServiceByGenericTypeKeyComparerReturnValidService()
+        {
+            var serviceA = serviceProvider.GetRequiredService<IDummyService, string>(
+                key => key == DummyServiceConstants.DummyServiceAKey);
+            var serviceB = serviceProvider.GetRequiredService<IDummyService, string>(
                 key => key == DummyServiceConstants.DummyServiceBKey);
 
             Assert.NotNull(serviceA as DummyServiceA);
@@ -111,6 +179,17 @@ namespace Microsoft.Extensions.NamedDependencyInjection.Tests.ServiceProviderExt
         }
 
         [Fact]
+        public void GetRequiredServiceByInvalidGenericTypeKeyComparerThrowException()
+        {
+            Assert.Throws<InvalidOperationException>(() =>
+                serviceProvider.GetRequiredService<DummyServiceA, string>(
+                    key => key == DummyServiceConstants.DummyServiceAKey));
+            Assert.Throws<InvalidOperationException>(() =>
+                serviceProvider.GetRequiredService<DummyServiceB, string>(
+                    key => key == DummyServiceConstants.DummyServiceBKey));
+        }
+
+        [Fact]
         public void GetServiceByGenericTypeByInvalidKeyComparerReturnNull()
         {
             var serviceA = serviceProvider.GetService<IDummyService, string>(key => key == "non_existing_key_a");
@@ -121,6 +200,15 @@ namespace Microsoft.Extensions.NamedDependencyInjection.Tests.ServiceProviderExt
         }
 
         [Fact]
+        public void GetRequiredServiceByGenericTypeByInvalidKeyComparerThrowException()
+        {
+            Assert.Throws<InvalidOperationException>(() =>
+                serviceProvider.GetRequiredService<IDummyService, string>(key => key == "non_existing_key_a"));
+            Assert.Throws<InvalidOperationException>(() =>
+                serviceProvider.GetRequiredService<IDummyService, string>(key => key == "non_existing_key_b"));
+        }
+
+        [Fact]
         public void GetDifferentServicesWithSameKeysByServiceTypeReturnValidServices()
         {
             var serviceA = serviceProvider.GetService(typeof(IDummyService), DummyServiceConstants.DummyServiceAKey);
@@ -128,6 +216,21 @@ namespace Microsoft.Extensions.NamedDependencyInjection.Tests.ServiceProviderExt
 
             var anotherServiceA = serviceProvider.GetService(typeof(IAnotherDummyService), DummyServiceConstants.DummyServiceAKey);
             var anotherServiceB = serviceProvider.GetService(typeof(IAnotherDummyService), DummyServiceConstants.DummyServiceBKey);
+
+            Assert.NotNull(serviceA as DummyServiceA);
+            Assert.NotNull(serviceB as DummyServiceB);
+            Assert.NotNull(anotherServiceA as AnotherDummyServiceA);
+            Assert.NotNull(anotherServiceB as AnotherDummyServiceB);
+        }
+
+        [Fact]
+        public void GetDifferentRequiredServicesWithSameKeysByServiceTypeReturnValidServices()
+        {
+            var serviceA = serviceProvider.GetRequiredService(typeof(IDummyService), DummyServiceConstants.DummyServiceAKey);
+            var serviceB = serviceProvider.GetRequiredService(typeof(IDummyService), DummyServiceConstants.DummyServiceBKey);
+
+            var anotherServiceA = serviceProvider.GetRequiredService(typeof(IAnotherDummyService), DummyServiceConstants.DummyServiceAKey);
+            var anotherServiceB = serviceProvider.GetRequiredService(typeof(IAnotherDummyService), DummyServiceConstants.DummyServiceBKey);
 
             Assert.NotNull(serviceA as DummyServiceA);
             Assert.NotNull(serviceB as DummyServiceB);
@@ -151,6 +254,21 @@ namespace Microsoft.Extensions.NamedDependencyInjection.Tests.ServiceProviderExt
         }
 
         [Fact]
+        public void GetDifferentRequiredServicesWithSameKeysByGenericTypeReturnValidServices()
+        {
+            var serviceA = serviceProvider.GetRequiredService<IDummyService, string>(DummyServiceConstants.DummyServiceAKey);
+            var serviceB = serviceProvider.GetRequiredService<IDummyService, string>(DummyServiceConstants.DummyServiceBKey);
+
+            var anotherServiceA = serviceProvider.GetRequiredService<IAnotherDummyService, string>(DummyServiceConstants.DummyServiceAKey);
+            var anotherServiceB = serviceProvider.GetRequiredService<IAnotherDummyService, string>(DummyServiceConstants.DummyServiceBKey);
+
+            Assert.NotNull(serviceA as DummyServiceA);
+            Assert.NotNull(serviceB as DummyServiceB);
+            Assert.NotNull(anotherServiceA as AnotherDummyServiceA);
+            Assert.NotNull(anotherServiceB as AnotherDummyServiceB);
+        }
+
+        [Fact]
         public void GetDifferentServicesWithSameKeysByGenericTypeKeyComparerReturnValidServices()
         {
             var serviceA = serviceProvider.GetService<IDummyService, string>(
@@ -161,6 +279,25 @@ namespace Microsoft.Extensions.NamedDependencyInjection.Tests.ServiceProviderExt
             var anotherServiceA = serviceProvider.GetService<IAnotherDummyService, string>(
                 key => key == DummyServiceConstants.DummyServiceAKey);
             var anotherServiceB = serviceProvider.GetService<IAnotherDummyService, string>(
+                key => key == DummyServiceConstants.DummyServiceBKey);
+
+            Assert.NotNull(serviceA as DummyServiceA);
+            Assert.NotNull(serviceB as DummyServiceB);
+            Assert.NotNull(anotherServiceA as AnotherDummyServiceA);
+            Assert.NotNull(anotherServiceB as AnotherDummyServiceB);
+        }
+
+        [Fact]
+        public void GetDifferentRequiredServicesWithSameKeysByGenericTypeKeyComparerReturnValidServices()
+        {
+            var serviceA = serviceProvider.GetRequiredService<IDummyService, string>(
+                key => key == DummyServiceConstants.DummyServiceAKey);
+            var serviceB = serviceProvider.GetRequiredService<IDummyService, string>(
+                key => key == DummyServiceConstants.DummyServiceBKey);
+
+            var anotherServiceA = serviceProvider.GetRequiredService<IAnotherDummyService, string>(
+                key => key == DummyServiceConstants.DummyServiceAKey);
+            var anotherServiceB = serviceProvider.GetRequiredService<IAnotherDummyService, string>(
                 key => key == DummyServiceConstants.DummyServiceBKey);
 
             Assert.NotNull(serviceA as DummyServiceA);


### PR DESCRIPTION
Used the same exception message as the original `GetRequiredService` method. It can be improved to show the value of `key` in the message, but there is a problem with the overload that takes a  comparer function.

Issue #18

Please review
Thank you in advance